### PR TITLE
add repository field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/patrickarlt/acetate-cli.git"
+  },
   "author": "Patrick Arlt",
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
adds repository field so `npm install` no longer shows warn error
